### PR TITLE
fix(sec): upgrade pygments to 2.7.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ interchange~=2021.0.4
 monotonic
 packaging
 pansi>=2020.7.3
-pygments>=2.0.0
+pygments>=2.7.4
 six>=1.15.0
 urllib3


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in pygments 2.0.0
- [CVE-2021-20270](https://www.oscs1024.com/hd/CVE-2021-20270)


### What did I do？
Upgrade pygments from 2.0.0 to 2.7.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS